### PR TITLE
feat(dataset): add generated chat dataset (508 samples)

### DIFF
--- a/data/chat-dataset/README.md
+++ b/data/chat-dataset/README.md
@@ -1,0 +1,13 @@
+# Chat Dataset (generated)
+
+- Source repo: https://github.com/ArjunDivecha/Factor-Timing-Value
+- Source commit (SHA): 808ae10182a50623216c23c9dc964a2a397de324
+- Counts: total=508, train=458, valid=50
+
+Command used:
+```
+gh-chat-dataset --repo https://github.com/ArjunDivecha/Factor-Timing-Value --out out/factor \
+  --md-max-questions-per-section 4 --md-window-tokens 800 \
+  --py-chunking --py-chunk-max 5 --py-chunk-min-lines 6 \
+  --max-tokens 4096 --min-tokens 48 --file-cap 15
+```


### PR DESCRIPTION
Adds generated chat dataset for Factor-Timing-Value.

- total: 508 (train: 458, valid: 50)
- source SHA: 808ae10182a50623216c23c9dc964a2a397de324
- files: data/chat-dataset/{dataset.train.jsonl,dataset.valid.jsonl,stats.json,README.md}

Generated with gh-chat-dataset using expanded coverage flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add README documenting the generated chat dataset, including source, counts, and the generation command.
> 
> - **Dataset docs**:
>   - Add `data/chat-dataset/README.md` documenting the generated chat dataset:
>     - Source repository and commit SHA
>     - Sample counts (`total`, `train`, `valid`)
>     - Generation command and key flags used
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13155cdbed77508fe06992d27dd0703aa74b6525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->